### PR TITLE
Update: fix bug with verifier sorting, finish implementing and use VerifierTableModel, and rename "Is Enabled" to "Activated"

### DIFF
--- a/src/main/java/edu/tamu/di/SAFCreator/model/VerifierTableModel.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/VerifierTableModel.java
@@ -5,113 +5,108 @@ import java.util.Vector;
 
 import javax.swing.table.AbstractTableModel;
 
-import edu.tamu.di.SAFCreator.model.verify.Verifier;
+import edu.tamu.di.SAFCreator.model.verify.VerifierProperty;
 
 public class VerifierTableModel extends AbstractTableModel {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
-    Vector<String> columnNames;// new Vector<String>();
-    Vector<Vector<Object>> rowData;// new Vector<Vector<Object>>();
 
-    // String[] columnNames = {"Blah", "Foo"};
-    // Object[][] data = {{1, 2}, {3, 4}};
+    public static final String COLUMN_VERIFIER = "Verifier";
+    public static final String COLUMN_GENERATES_ERRORS = "Generates Errors";
+    public static final String COLUMN_ACTIVATED = "Activated";
 
-    // public MyTableModel()
-    // {
-    // String[] columnNames = {"Blah", "Foo"};
-    // Object[][] data = {{1, 2}, {3, 4}};
-    // }
+    public static final String VERIFIER_ACTIVE = "Active";
+    public static final String VERIFIER_INACTIVE = "Inactive";
 
-    public VerifierTableModel(List<Verifier> verifiers) {
-        System.out.println("Called!");
+    private Vector<String> columnNames;
+    private Vector<Vector<Object>> rowData;
+
+    private Vector<String> verifierNames;
+    private Vector<VerifierProperty> verifierProperties;
+
+
+    public VerifierTableModel(List<VerifierProperty> verifiers) {
         columnNames = new Vector<String>();
         rowData = new Vector<Vector<Object>>();
 
-        columnNames.add("Verifier");
-        columnNames.add("Activated");
+        verifierNames = new Vector<String>();
+        verifierProperties = new Vector<VerifierProperty>();
 
-        Vector<Vector<Object>> rowData = new Vector<Vector<Object>>();
+        columnNames.add(COLUMN_VERIFIER);
+        columnNames.add(COLUMN_GENERATES_ERRORS);
+        columnNames.add(COLUMN_ACTIVATED);
 
-        for (Verifier verifier : verifiers) {
-            System.out.println("Adding verifier  " + verifier.getClass().getSimpleName());
+        for (VerifierProperty verifier : verifiers) {
             Vector<Object> row = new Vector<Object>();
 
-            row.add(verifier.getClass().getName());
-            row.add(true);
+            row.add(verifier.prettyName());
+            row.add(verifier.generatesError());
+            row.add(verifier.getActivated() ? VERIFIER_ACTIVE : VERIFIER_INACTIVE);
+
+            verifierNames.add(verifier.getClass().getName());
+            verifierProperties.add(verifier);
 
             rowData.add(row);
         }
-        System.out.println(rowData.size() + " rows.");
     }
 
     @Override
     public int getColumnCount() {
-        // System.out.println("columnData size " + columnNames.size());
         return columnNames.size();
     }
 
     @Override
     public String getColumnName(int col) {
-        System.out.println("getting column name " + col + ": " + columnNames.get(col));
         return columnNames.get(col);
     }
 
     @Override
     public int getRowCount() {
-        System.out.println("Now I claim " + rowData.size() + " rows, but columns stayed at " + getColumnCount());
         return rowData.size();
-        // return 1;
     }
 
     @Override
     public Object getValueAt(int row, int col) {
-        System.out.println("getting datum " + row + ", " + col + ":" + rowData.get(row).get(col));
-        return rowData.get(row).get(col);
+        Object object = null;
+        if (row >= 0 && row < rowData.size()) {
+            object = rowData.get(row).get(col);
+        }
+        return object;
     }
 
-    // public int getColumnCount() {
-    // return columnNames.length;
-    // }
-    //
-    // public int getRowCount() {
-    // return data.length;
-    // }
-    //
-    // public String getColumnName(int col) {
-    // return columnNames[col];
-    // }
-    //
-    // public Object getValueAt(int row, int col) {
-    // return data[row][col];
-    // }
+    public VerifierProperty getVerifierPropertyAt(int row) {
+        VerifierProperty verifierProperty = null;
+        if (row >= 0 && row < verifierProperties.size()) {
+            verifierProperty = verifierProperties.get(row);
+        }
+        return verifierProperty;
+    }
 
-    // @Override
-    // public Class<? extends Object> getColumnClass(int c) {
-    // return getValueAt(0, c).getClass();
-    // }
+    public VerifierProperty getVerifierWithName(String name) {
+        VerifierProperty verifierProperty = null;
+        int row = 0;
+        String verifierName = null;
 
-    /*
-     * Don't need to implement this method unless your table's editable.
-     */
-    // public boolean isCellEditable(int row, int col) {
-    // //Note that the data/cell address is constant,
-    // //no matter where the cell appears onscreen.
-    // if (col > 1) {
-    // return true;
-    // } else {
-    // return false;
-    // }
-    // }
+        for (; row < verifierProperties.size(); row++) {
+            verifierName = verifierNames.get(row);
+            if (verifierName.equals(name)) {
+                break;
+            }
+        }
 
-    /*
-     * Don't need to implement this method unless your table's data can change.
-     */
-    // public void setValueAt(Object value, int row, int col) {
-    // rowData.get(row).set(col, value);
-    // fireTableCellUpdated(row, col);
-    // }
+        if (row < rowData.size()) {
+            verifierProperty = verifierProperties.get(row);
+        }
+
+        return verifierProperty;
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int column) {
+        rowData.get(row).set(column, value);
+        if (column == 2) {
+            getVerifierPropertyAt(row).setActivated(value.equals(VERIFIER_ACTIVE));
+        }
+        fireTableCellUpdated(row, column);
+    }
 
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierBackground.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierBackground.java
@@ -47,7 +47,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
 
     public VerifierBackground(VerifierProperty settings) {
         this();
-        enabled = settings.isEnabled();
+        enabled = settings.getActivated();
     }
 
     /**
@@ -63,7 +63,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
     }
 
     @Override
-    public boolean isEnabled() {
+    public boolean getActivated() {
         return enabled;
     }
 
@@ -73,7 +73,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
     }
 
     @Override
-    public void setEnabled(boolean enabled) {
+    public void setActivated(boolean enabled) {
         this.enabled = enabled;
     }
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierProperty.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierProperty.java
@@ -3,11 +3,11 @@ package edu.tamu.di.SAFCreator.model.verify;
 public interface VerifierProperty {
     public boolean generatesError();
 
-    public boolean isEnabled();
+    public boolean getActivated();
 
     public boolean isSwingWorker();
 
     public String prettyName();
 
-    public void setEnabled(boolean enabled);
+    public void setActivated(boolean activated);
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -4,11 +4,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Vector;
-import java.util.Map.Entry;
 
 
 import javax.swing.BorderFactory;
@@ -26,9 +22,9 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EtchedBorder;
-import javax.swing.table.DefaultTableModel;
 
 import edu.tamu.di.SAFCreator.model.FlagPanel;
+import edu.tamu.di.SAFCreator.model.VerifierTableModel;
 import edu.tamu.di.SAFCreator.model.verify.VerifierProperty;
 import edu.tamu.di.SAFCreator.model.verify.impl.LocalFilesExistVerifierImpl;
 import edu.tamu.di.SAFCreator.model.verify.impl.RemoteFilesExistVerifierImpl;
@@ -104,9 +100,8 @@ public final class UserInterfaceView extends JFrame {
     private final JButton verifyCancelBtn = new JButton("Cancel");
 
     private final JTable verifierTbl = new JTable();
-
-    private final Map<String, VerifierProperty> verifierSettings = new HashMap<String, VerifierProperty>();
-    private final List<String> verifierNamesMap = new ArrayList<String>();
+    private final VerifierTableModel verifierTableModel;
+    private List<VerifierProperty> verifierProperties = new ArrayList<VerifierProperty>();
 
 
     // Components of the Advanced Settings tab
@@ -139,7 +134,15 @@ public final class UserInterfaceView extends JFrame {
 
 
     public UserInterfaceView() {
-        createVerifierSettings();
+        VerifierProperty validSchemaVerifier = new ValidSchemaNameVerifierImpl();
+        VerifierProperty localFileExistsVerifier = new LocalFilesExistVerifierImpl();
+        VerifierProperty remoteFileExistsVerifier = new RemoteFilesExistVerifierImpl();
+
+        verifierProperties.add(validSchemaVerifier);
+        verifierProperties.add(localFileExistsVerifier);
+        verifierProperties.add(remoteFileExistsVerifier);
+
+        verifierTableModel = new VerifierTableModel(verifierProperties);
 
         createBatchDetailsTab();
 
@@ -333,6 +336,10 @@ public final class UserInterfaceView extends JFrame {
         return tabs;
     }
 
+    public VerifierTableModel getTableModel() {
+        return verifierTableModel;
+    }
+
     public JTextField getUserAgentField() {
         return userAgentField;
     }
@@ -343,14 +350,6 @@ public final class UserInterfaceView extends JFrame {
 
     public JPanel getValidationTab() {
         return validationTab;
-    }
-
-    public List<String> getVerifierNamesMap() {
-        return verifierNamesMap;
-    }
-
-    public Map<String, VerifierProperty> getVerifierSettings() {
-        return verifierSettings;
     }
 
     public JTable getVerifierTbl() {
@@ -457,6 +456,7 @@ public final class UserInterfaceView extends JFrame {
         flagsDownloadCsvBtn.setEnabled(false);
         flagsReportSelectedBtn.setEnabled(false);
     }
+
     private void createLicenseTab() {
         licenseTab.setLayout(new BoxLayout(licenseTab, BoxLayout.Y_AXIS));
 
@@ -491,35 +491,14 @@ public final class UserInterfaceView extends JFrame {
     }
 
     private void createVerificationTab() {
-        validationTab.setLayout(new BoxLayout(validationTab, BoxLayout.Y_AXIS));
-
-        Vector<String> columnNames = new Vector<String>();
-        Vector<Vector<Object>> rowData = new Vector<Vector<Object>>();
-
-        columnNames.add("Verifier");
-        columnNames.add("Generates Errors");
-        columnNames.add("Is Enabled");
-
-        for (Entry<String, VerifierProperty> entry : verifierSettings.entrySet()) {
-            VerifierProperty verifier = entry.getValue();
-            Vector<Object> row = new Vector<Object>();
-
-            row.add(verifier.prettyName());
-            row.add(verifier.generatesError());
-            row.add(verifier.isEnabled());
-
-            verifierNamesMap.add(verifier.getClass().getName());
-
-            rowData.add(row);
-        }
-
-        verifierTbl.setModel(new DefaultTableModel(rowData, columnNames));
+        verifierTbl.setModel(verifierTableModel);
         verifierTbl.setPreferredScrollableViewportSize(new Dimension(400, 50));
         verifierTbl.setEnabled(false);
 
         JScrollPane verifierTblScrollPane = new JScrollPane(verifierTbl);
         verifierTbl.setFillsViewportHeight(true);
-        verifierTbl.setAutoCreateRowSorter(true);
+
+        validationTab.setLayout(new BoxLayout(validationTab, BoxLayout.Y_AXIS));
 
         validationTab.add(verifierTblScrollPane);
 
@@ -530,17 +509,6 @@ public final class UserInterfaceView extends JFrame {
         validationTab.add(verifyBatchBtnPanel);
 
         tabs.addTab("Batch Verification", validationTab);
-    }
-
-    private void createVerifierSettings() {
-        VerifierProperty validSchemaVerifier = new ValidSchemaNameVerifierImpl();
-        verifierSettings.put(ValidSchemaNameVerifierImpl.class.getName(), validSchemaVerifier);
-
-        VerifierProperty localFileExistsVerifier = new LocalFilesExistVerifierImpl();
-        verifierSettings.put(LocalFilesExistVerifierImpl.class.getName(), localFileExistsVerifier);
-
-        VerifierProperty remoteFileExistsVerifier = new RemoteFilesExistVerifierImpl();
-        verifierSettings.put(RemoteFilesExistVerifierImpl.class.getName(), remoteFileExistsVerifier);
     }
 
     private void initializeState() {


### PR DESCRIPTION
Changing the sorting causes the verifier properties to not match to the correct row, breaking the enable/disabled toggle.

I noticed that I overlooked the existence of VerifierTableModel during the refactor.
This class should be completed and the verififier properties storage is redesigned to utilize this.

Rename "Is Enabled" to "Activated" to match the naming scheme that was already provided in the VerifierTableModel.