### PR TITLE
Remote file problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,9 @@
 		<version>3.6</version>
 	</dependency>
 	<dependency>
-		<groupId>commons-httpclient</groupId>
-		<artifactId>commons-httpclient</artifactId>
-		<version>3.0</version>
+		<groupId>org.apache.httpcomponents</groupId>
+		<artifactId>httpclient</artifactId>
+		<version>4.5.6</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.commons</groupId>

--- a/src/main/java/edu/tamu/di/SAFCreator/App.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/App.java
@@ -18,6 +18,10 @@ public class App {
 
 
     public static void main(String[] args) {
+        // disable SNI, which must be set before any SSL connection is opened or it will not have any effect.
+        // this avoids "SSL handshake alert: unrecognized_name".
+        System.setProperty("jsse.enableSNIExtension", "false");
+
         view.setSize(800, 640);
         view.setResizable(false);
         view.setVisible(true);

--- a/src/main/java/edu/tamu/di/SAFCreator/controller/UserInterfaceController.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/controller/UserInterfaceController.java
@@ -982,11 +982,12 @@ public class UserInterfaceController {
     }
 
     private void createSettingsListeners() {
-        userInterface.getIgnoreFilesBox().addMouseListener(new MouseListener() {
+        userInterface.getIgnoreFilesBox().addActionListener(new ActionListener() {
+
             @Override
-            public void mouseClicked(MouseEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 if (!userInterface.getIgnoreFilesBox().isEnabled()) {
-                    // checkbox mouse clicks still trigger even when set to disabled.
+                    // do nothing when field is disabled.
                     return;
                 }
 
@@ -998,29 +999,13 @@ public class UserInterfaceController {
                     batch.setIgnoreFiles(false);
                 }
             }
-
-            @Override
-            public void mouseEntered(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseExited(MouseEvent e) {
-            }
-
-            @Override
-            public void mousePressed(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent e) {
-            }
         });
 
-        userInterface.getContinueOnRemoteErrorBox().addMouseListener(new MouseListener() {
+        userInterface.getContinueOnRemoteErrorBox().addActionListener(new ActionListener() {
             @Override
-            public void mouseClicked(MouseEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 if (!userInterface.getContinueOnRemoteErrorBox().isEnabled()) {
-                    // checkbox mouse clicks still trigger even when set to disabled.
+                    // do nothing when field is disabled.
                     return;
                 }
 
@@ -1032,29 +1017,13 @@ public class UserInterfaceController {
                     batch.setRemoteBitstreamErrorContinue(false);
                 }
             }
-
-            @Override
-            public void mouseEntered(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseExited(MouseEvent e) {
-            }
-
-            @Override
-            public void mousePressed(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent e) {
-            }
         });
 
-        userInterface.getAllowSelfSignedBox().addMouseListener(new MouseListener() {
+        userInterface.getAllowSelfSignedBox().addActionListener(new ActionListener() {
             @Override
-            public void mouseClicked(MouseEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 if (!userInterface.getIgnoreFilesBox().isEnabled()) {
-                    // checkbox mouse clicks still trigger even when set to disabled.
+                    // do nothing when field is disabled.
                     return;
                 }
 
@@ -1066,22 +1035,6 @@ public class UserInterfaceController {
                     userInterface.getConsole().append("Self-Signed SSL Certificates will not always be allowed when generating SAF.\n");
                     batch.setAllowSelfSigned(false);
                 }
-            }
-
-            @Override
-            public void mouseEntered(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseExited(MouseEvent e) {
-            }
-
-            @Override
-            public void mousePressed(MouseEvent e) {
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent e) {
             }
         });
 

--- a/src/main/java/edu/tamu/di/SAFCreator/controller/UserInterfaceController.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/controller/UserInterfaceController.java
@@ -384,6 +384,7 @@ public class UserInterfaceController {
         if (actionStatus != ActionStatus.NONE_LOADED) {
             userInterface.getIgnoreFilesBox().setEnabled(false);
             userInterface.getContinueOnRemoteErrorBox().setEnabled(false);
+            userInterface.getAllowSelfSignedBox().setEnabled(false);
             userInterface.getItemProcessDelayField().setEnabled(false);
             userInterface.getRemoteFileTimeoutField().setEnabled(false);
             userInterface.getUserAgentField().setEnabled(false);
@@ -434,6 +435,7 @@ public class UserInterfaceController {
 
         batch.setIgnoreFiles(userInterface.getIgnoreFilesBox().isSelected());
         batch.setRemoteBitstreamErrorContinue(userInterface.getContinueOnRemoteErrorBox().isSelected());
+        batch.setAllowSelfSigned(userInterface.getAllowSelfSignedBox().isSelected());
         batch.setItemProcessDelay(userInterface.getItemProcessDelayField().getText());
         batch.setUserAgent(userInterface.getUserAgentField().getText());
 
@@ -441,6 +443,7 @@ public class UserInterfaceController {
 
         userInterface.getIgnoreFilesBox().setEnabled(true);
         userInterface.getContinueOnRemoteErrorBox().setEnabled(true);
+        userInterface.getAllowSelfSignedBox().setEnabled(true);
         userInterface.getItemProcessDelayField().setEnabled(true);
         userInterface.getRemoteFileTimeoutField().setEnabled(true);
         userInterface.getUserAgentField().setEnabled(true);
@@ -563,6 +566,7 @@ public class UserInterfaceController {
         if (actionStatus != ActionStatus.NONE_LOADED) {
             userInterface.getIgnoreFilesBox().setEnabled(true);
             userInterface.getContinueOnRemoteErrorBox().setEnabled(true);
+            userInterface.getAllowSelfSignedBox().setEnabled(true);
             userInterface.getItemProcessDelayField().setEnabled(true);
             userInterface.getRemoteFileTimeoutField().setEnabled(true);
             userInterface.getUserAgentField().setEnabled(true);
@@ -598,6 +602,7 @@ public class UserInterfaceController {
 
                         userInterface.getIgnoreFilesBox().setEnabled(false);
                         userInterface.getContinueOnRemoteErrorBox().setEnabled(false);
+                        userInterface.getAllowSelfSignedBox().setEnabled(false);
                         userInterface.getItemProcessDelayField().setEnabled(false);
                         userInterface.getRemoteFileTimeoutField().setEnabled(false);
                         userInterface.getUserAgentField().setEnabled(false);
@@ -654,6 +659,7 @@ public class UserInterfaceController {
 
                         userInterface.getIgnoreFilesBox().setEnabled(false);
                         userInterface.getContinueOnRemoteErrorBox().setEnabled(false);
+                        userInterface.getAllowSelfSignedBox().setEnabled(false);
                         userInterface.getItemProcessDelayField().setEnabled(false);
                         userInterface.getRemoteFileTimeoutField().setEnabled(false);
                         userInterface.getUserAgentField().setEnabled(false);
@@ -1024,6 +1030,41 @@ public class UserInterfaceController {
                 } else {
                     userInterface.getConsole().append("Denying write if the remote bitstream verification flags an error.\n");
                     batch.setRemoteBitstreamErrorContinue(false);
+                }
+            }
+
+            @Override
+            public void mouseEntered(MouseEvent e) {
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+            }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+            }
+        });
+
+        userInterface.getAllowSelfSignedBox().addMouseListener(new MouseListener() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (!userInterface.getIgnoreFilesBox().isEnabled()) {
+                    // checkbox mouse clicks still trigger even when set to disabled.
+                    return;
+                }
+
+                if (userInterface.getAllowSelfSignedBox().isSelected()) {
+                    userInterface.getConsole().append("Self-Signed SSL Certificates will always be allowed when generating SAF.\n");
+                    batch.setAllowSelfSigned(true);
+                }
+                else {
+                    userInterface.getConsole().append("Self-Signed SSL Certificates will not always be allowed when generating SAF.\n");
+                    batch.setAllowSelfSigned(false);
                 }
             }
 

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Batch.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Batch.java
@@ -16,6 +16,7 @@ public class Batch {
     private List<ColumnLabel> labels = new ArrayList<ColumnLabel>();
     private Boolean ignoreFiles = false;
     private Boolean processUri = false;
+    private Boolean allowSelfSigned = true;
     private Boolean remoteBitstreamErrorContinue = false;
     private int itemProcessDelay = 0;
     private int remoteFileTimeout = 10000;
@@ -64,6 +65,16 @@ public class Batch {
         return action;
     }
 
+    /**
+     * @return Whether or not self-signed certificates are always allowed.
+     */
+    public Boolean getAllowSelfSigned() {
+        return allowSelfSigned;
+    }
+
+    /**
+     * @return Whether or not to ignore files.
+     */
     public Boolean getIgnoreFiles() {
         return ignoreFiles;
     }
@@ -222,6 +233,20 @@ public class Batch {
         this.action = action;
     }
 
+    /**
+     * Set the whether or not to always allow self-signed SSL certificates.
+     *
+     * @param allowSelfSigned
+     */
+    public void setAllowSelfSigned(Boolean allowSelfSigned) {
+        this.allowSelfSigned = allowSelfSigned;
+    }
+
+    /**
+     * Set the whether or not to ignore files.
+     *
+     * @param ignoreFiles
+     */
     public void setIgnoreFiles(Boolean ignoreFiles) {
         this.ignoreFiles = ignoreFiles;
     }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
@@ -215,10 +215,12 @@ public class Bitstream extends CellDatumImpl {
                             FileUtils.copyToFile(input, destination);
                             input.close();
 
-                            String contentTypeHeader = get.getResponseHeader("Content-Type").getValue();
+
+                            Header contentTypeHeader = get.getResponseHeader("Content-Type");
+                            String contentTypeHeaderValue = contentTypeHeader == null ? "" : contentTypeHeader.getValue();
                             get.releaseConnection();
 
-                            String[] contentTypeHeaderParts = contentTypeHeader.split("[;]");
+                            String[] contentTypeHeaderParts = contentTypeHeaderValue.split("[;]");
                             String contentType = "";
                             if (contentTypeHeaderParts.length > 0) {
                                 contentType = contentTypeHeaderParts[0];

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
@@ -253,8 +253,8 @@ public class Bitstream extends CellDatumImpl {
 
                             Problem problem = null;
                             MimeType originalMimeType = mimeType;
-                            if (contentType.equalsIgnoreCase("text/html")) {
-                                Flag flag = new Flag(Flag.INVALID_MIME, "HTTP URL did not return the expected file, reason: an HTML page was returned.", action, this);
+                            if (contentType.equalsIgnoreCase("text/html") || contentType.equalsIgnoreCase("text/plain")) {
+                                Flag flag = new Flag(Flag.INVALID_MIME, "HTTP URL did not return the expected file, reason: an HTML page or plain text page was returned.", action, this);
                                 problem = new Problem(getRow(), getColumnLabel(), true, "HTTP URL did not return the expected file.", flag);
                                 problems.add(problem);
                             }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
@@ -408,8 +408,7 @@ public class Bitstream extends CellDatumImpl {
             MediaType mediaType = detector.detect(tikaStream, metadata);
             setMimeType(mediaType.toString());
         } catch (MimeTypeException e) {
-            return new Flag(Flag.INVALID_MIME, "Unable to determine mime type of file, reason: " + e.getMessage() + ".",
-                    action, this);
+            return new Flag(Flag.INVALID_MIME, "Unable to determine mime type of file, reason: " + e.getMessage() + ".", action, this);
         } catch (IOException e) {
             return new Flag(Flag.IO_FAILURE, "File read failed, reason: " + e.getMessage() + ".", action, this);
         } finally {

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Bitstream.java
@@ -251,47 +251,60 @@ public class Bitstream extends CellDatumImpl {
                                 }
                             }
 
+                            Problem problem = null;
                             MimeType originalMimeType = mimeType;
-                            if (contentType.equalsIgnoreCase("application/octet-stream")) {
+                            if (contentType.equalsIgnoreCase("text/html")) {
+                                Flag flag = new Flag(Flag.INVALID_MIME, "HTTP URL did not return the expected file, reason: an HTML page was returned.", action, this);
+                                problem = new Problem(getRow(), getColumnLabel(), true, "HTTP URL did not return the expected file.", flag);
+                                problems.add(problem);
+                            }
+                            else if (contentType.equalsIgnoreCase("application/octet-stream")) {
                                 Flag flag = determineMimeType(destination);
                                 if (flag != null) {
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
                                     problems.add(problem);
                                 } else if (mimeType == null || mimeType.toString().isEmpty()) {
                                     flag = new Flag(Flag.INVALID_MIME, "HTTP URL may not be a valid file, reason: unable to determine mime-type.", action, this);
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid file.", flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid file.", flag);
                                     problems.add(problem);
                                     mimeType = originalMimeType;
                                 }
                             } else if (contentType.equalsIgnoreCase("application/pdf")) {
                                 Flag flag = determineMimeType(destination);
                                 if (flag != null) {
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
                                     problems.add(problem);
                                 } else if (!contentType.equalsIgnoreCase(mimeType.toString())) {
                                     flag = new Flag(Flag.INVALID_MIME, "HTTP URL may not be a valid PDF, reason: server designated a mimetype of " + contentType + ", detected mimetype is " + mimeType + ".", action, this);
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid PDF.", flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid PDF.", flag);
                                     problems.add(problem);
                                     mimeType = originalMimeType;
                                 }
                             } else if (contentType.equalsIgnoreCase("image/png") || contentType.equalsIgnoreCase("image/jpg") || contentType.equalsIgnoreCase("image/jpeg") || contentType.equalsIgnoreCase("image/gif")) {
                                 Flag flag = determineMimeType(destination);
                                 if (flag != null) {
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
                                     problems.add(problem);
                                 } else if (!contentType.equalsIgnoreCase(mimeType.toString())) {
                                     flag = new Flag(Flag.INVALID_MIME, "HTTP URL may not be a valid image, reason: server designated a mimetype of " + contentType + ", detected mimetype is " + mimeType + ".", action, this);
-                                    Problem problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid image.", flag);
+                                    problem = new Problem(getRow(), getColumnLabel(), false, "HTTP URL may not be a valid image.", flag);
                                     problems.add(problem);
                                     mimeType = originalMimeType;
                                 }
                             }
 
                             // rename destination file on mime type change.
-                            Flag flag = renameFileUsingMimeType(destination, originalMimeType);
-                            if (flag != null) {
-                                Problem problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
-                                problems.add(problem);
+                            if (problem == null) {
+                                Flag flag = renameFileUsingMimeType(destination, originalMimeType);
+                                if (flag != null) {
+                                    problem = new Problem(getRow(), getColumnLabel(), true, flag.getCell(FlagColumns.DESCRIPTION), flag);
+                                    problems.add(problem);
+                                }
+                            }
+                            else {
+                                if (problem.isError() && destination.exists()) {
+                                    destination.delete();
+                                }
                             }
                         } else if (responseCode != java.net.HttpURLConnection.HTTP_SEE_OTHER && responseCode != java.net.HttpURLConnection.HTTP_MOVED_PERM && responseCode != java.net.HttpURLConnection.HTTP_MOVED_TEMP) {
                             if (responseCode == 304 || responseCode == 509) {

--- a/src/main/java/edu/tamu/di/SAFCreator/model/Item.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/Item.java
@@ -155,12 +155,10 @@ public class Item {
             }
             Util.setFileContents(contentsFile, contentsString);
         } catch (FileNotFoundException e) {
-            Problem problem = new Problem(true, "Unable to write to missing contents file for item directory "
-                    + getSAFDirectory() + ", reason: " + e.getMessage());
+            Problem problem = new Problem(true, "Unable to write to missing contents file for item directory " + getSAFDirectory() + ", reason: " + e.getMessage());
             problems.add(problem);
         } catch (IOException e) {
-            Problem problem = new Problem(true, "Error writing contents file for item directory " + getSAFDirectory()
-                    + ", reason: " + e.getMessage());
+            Problem problem = new Problem(true, "Error writing contents file for item directory " + getSAFDirectory() + ", reason: " + e.getMessage());
             problems.add(problem);
         }
     }
@@ -173,12 +171,10 @@ public class Item {
             }
             Util.setFileContents(handleFile, getHandle());
         } catch (FileNotFoundException e) {
-            Problem problem = new Problem(true, "Unable to write to missing handle file for item directory "
-                    + getSAFDirectory() + ", reason: " + e.getMessage());
+            Problem problem = new Problem(true, "Unable to write to missing handle file for item directory " + getSAFDirectory() + ", reason: " + e.getMessage());
             problems.add(problem);
         } catch (IOException e) {
-            Problem problem = new Problem(true, "Error writing handle file for item directory " + getSAFDirectory()
-                    + ", reason: " + e.getMessage());
+            Problem problem = new Problem(true, "Error writing handle file for item directory " + getSAFDirectory() + ", reason: " + e.getMessage());
             problems.add(problem);
         }
     }
@@ -193,12 +189,10 @@ public class Item {
                 }
                 Util.setFileContents(metadataFile, schema.getXML());
             } catch (FileNotFoundException e) {
-                Problem problem = new Problem(true, "Unable to write to missing metadata file "
-                        + metadataFile.getAbsolutePath() + ", reason: " + e.getMessage());
+                Problem problem = new Problem(true, "Unable to write to missing metadata file " + metadataFile.getAbsolutePath() + ", reason: " + e.getMessage());
                 problems.add(problem);
             } catch (IOException e) {
-                Problem problem = new Problem(true, "Unable to create metadata file " + metadataFile.getAbsolutePath()
-                        + ", reason: " + e.getMessage());
+                Problem problem = new Problem(true, "Unable to create metadata file " + metadataFile.getAbsolutePath() + ", reason: " + e.getMessage());
                 problems.add(problem);
             }
         }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/VerifierTableModel.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/VerifierTableModel.java
@@ -5,113 +5,108 @@ import java.util.Vector;
 
 import javax.swing.table.AbstractTableModel;
 
-import edu.tamu.di.SAFCreator.model.verify.Verifier;
+import edu.tamu.di.SAFCreator.model.verify.VerifierProperty;
 
 public class VerifierTableModel extends AbstractTableModel {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
-    Vector<String> columnNames;// new Vector<String>();
-    Vector<Vector<Object>> rowData;// new Vector<Vector<Object>>();
 
-    // String[] columnNames = {"Blah", "Foo"};
-    // Object[][] data = {{1, 2}, {3, 4}};
+    public static final String COLUMN_VERIFIER = "Verifier";
+    public static final String COLUMN_GENERATES_ERRORS = "Generates Errors";
+    public static final String COLUMN_ACTIVATED = "Activated";
 
-    // public MyTableModel()
-    // {
-    // String[] columnNames = {"Blah", "Foo"};
-    // Object[][] data = {{1, 2}, {3, 4}};
-    // }
+    public static final String VERIFIER_ACTIVE = "Active";
+    public static final String VERIFIER_INACTIVE = "Inactive";
 
-    public VerifierTableModel(List<Verifier> verifiers) {
-        System.out.println("Called!");
+    private Vector<String> columnNames;
+    private Vector<Vector<Object>> rowData;
+
+    private Vector<String> verifierNames;
+    private Vector<VerifierProperty> verifierProperties;
+
+
+    public VerifierTableModel(List<VerifierProperty> verifiers) {
         columnNames = new Vector<String>();
         rowData = new Vector<Vector<Object>>();
 
-        columnNames.add("Verifier");
-        columnNames.add("Activated");
+        verifierNames = new Vector<String>();
+        verifierProperties = new Vector<VerifierProperty>();
 
-        Vector<Vector<Object>> rowData = new Vector<Vector<Object>>();
+        columnNames.add(COLUMN_VERIFIER);
+        columnNames.add(COLUMN_GENERATES_ERRORS);
+        columnNames.add(COLUMN_ACTIVATED);
 
-        for (Verifier verifier : verifiers) {
-            System.out.println("Adding verifier  " + verifier.getClass().getSimpleName());
+        for (VerifierProperty verifier : verifiers) {
             Vector<Object> row = new Vector<Object>();
 
-            row.add(verifier.getClass().getName());
-            row.add(true);
+            row.add(verifier.prettyName());
+            row.add(verifier.generatesError());
+            row.add(verifier.getActivated() ? VERIFIER_ACTIVE : VERIFIER_INACTIVE);
+
+            verifierNames.add(verifier.getClass().getName());
+            verifierProperties.add(verifier);
 
             rowData.add(row);
         }
-        System.out.println(rowData.size() + " rows.");
     }
 
     @Override
     public int getColumnCount() {
-        // System.out.println("columnData size " + columnNames.size());
         return columnNames.size();
     }
 
     @Override
     public String getColumnName(int col) {
-        System.out.println("getting column name " + col + ": " + columnNames.get(col));
         return columnNames.get(col);
     }
 
     @Override
     public int getRowCount() {
-        System.out.println("Now I claim " + rowData.size() + " rows, but columns stayed at " + getColumnCount());
         return rowData.size();
-        // return 1;
     }
 
     @Override
     public Object getValueAt(int row, int col) {
-        System.out.println("getting datum " + row + ", " + col + ":" + rowData.get(row).get(col));
-        return rowData.get(row).get(col);
+        Object object = null;
+        if (row >= 0 && row < rowData.size()) {
+            object = rowData.get(row).get(col);
+        }
+        return object;
     }
 
-    // public int getColumnCount() {
-    // return columnNames.length;
-    // }
-    //
-    // public int getRowCount() {
-    // return data.length;
-    // }
-    //
-    // public String getColumnName(int col) {
-    // return columnNames[col];
-    // }
-    //
-    // public Object getValueAt(int row, int col) {
-    // return data[row][col];
-    // }
+    public VerifierProperty getVerifierPropertyAt(int row) {
+        VerifierProperty verifierProperty = null;
+        if (row >= 0 && row < verifierProperties.size()) {
+            verifierProperty = verifierProperties.get(row);
+        }
+        return verifierProperty;
+    }
 
-    // @Override
-    // public Class<? extends Object> getColumnClass(int c) {
-    // return getValueAt(0, c).getClass();
-    // }
+    public VerifierProperty getVerifierWithName(String name) {
+        VerifierProperty verifierProperty = null;
+        int row = 0;
+        String verifierName = null;
 
-    /*
-     * Don't need to implement this method unless your table's editable.
-     */
-    // public boolean isCellEditable(int row, int col) {
-    // //Note that the data/cell address is constant,
-    // //no matter where the cell appears onscreen.
-    // if (col > 1) {
-    // return true;
-    // } else {
-    // return false;
-    // }
-    // }
+        for (; row < verifierProperties.size(); row++) {
+            verifierName = verifierNames.get(row);
+            if (verifierName.equals(name)) {
+                break;
+            }
+        }
 
-    /*
-     * Don't need to implement this method unless your table's data can change.
-     */
-    // public void setValueAt(Object value, int row, int col) {
-    // rowData.get(row).set(col, value);
-    // fireTableCellUpdated(row, col);
-    // }
+        if (row < rowData.size()) {
+            verifierProperty = verifierProperties.get(row);
+        }
+
+        return verifierProperty;
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int column) {
+        rowData.get(row).set(column, value);
+        if (column == 2) {
+            getVerifierPropertyAt(row).setActivated(value.equals(VERIFIER_ACTIVE));
+        }
+        fireTableCellUpdated(row, column);
+    }
 
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/importData/ImportDataProcessorImpl.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/importData/ImportDataProcessorImpl.java
@@ -296,7 +296,15 @@ public class ImportDataProcessorImpl implements ImportDataProcessor {
                                         }
                                     }
                                 } else {
-                                    URI fileUri = URI.create(batch.getinputFilesDir() + File.separator + value);
+                                    String fileUriPath = batch.getinputFilesDir() + File.separator + value;
+                                    URI fileUri = null;
+                                    try {
+                                        fileUri = URI.create(fileUriPath);
+                                    } catch (IllegalArgumentException e) {
+                                        console.append("\tERROR: CSV file reader failed to read line " + linenumber + " due to invalid URI: '" + fileUriPath + "'.\n");
+                                        errorState = true;
+                                    }
+
                                     if (fileUri != null) {
                                         Bitstream bitstream = new Bitstream();
                                         bitstream.setBundle(bundle);

--- a/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierBackground.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierBackground.java
@@ -47,7 +47,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
 
     public VerifierBackground(VerifierProperty settings) {
         this();
-        enabled = settings.isEnabled();
+        enabled = settings.getActivated();
     }
 
     /**
@@ -63,7 +63,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
     }
 
     @Override
-    public boolean isEnabled() {
+    public boolean getActivated() {
         return enabled;
     }
 
@@ -73,7 +73,7 @@ public abstract class VerifierBackground extends SwingWorker<List<Problem>, Veri
     }
 
     @Override
-    public void setEnabled(boolean enabled) {
+    public void setActivated(boolean enabled) {
         this.enabled = enabled;
     }
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierProperty.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/model/verify/VerifierProperty.java
@@ -3,11 +3,11 @@ package edu.tamu.di.SAFCreator.model.verify;
 public interface VerifierProperty {
     public boolean generatesError();
 
-    public boolean isEnabled();
+    public boolean getActivated();
 
     public boolean isSwingWorker();
 
     public String prettyName();
 
-    public void setEnabled(boolean enabled);
+    public void setActivated(boolean activated);
 }

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -4,11 +4,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Vector;
-import java.util.Map.Entry;
 
 
 import javax.swing.BorderFactory;
@@ -26,9 +22,9 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EtchedBorder;
-import javax.swing.table.DefaultTableModel;
 
 import edu.tamu.di.SAFCreator.model.FlagPanel;
+import edu.tamu.di.SAFCreator.model.VerifierTableModel;
 import edu.tamu.di.SAFCreator.model.verify.VerifierProperty;
 import edu.tamu.di.SAFCreator.model.verify.impl.LocalFilesExistVerifierImpl;
 import edu.tamu.di.SAFCreator.model.verify.impl.RemoteFilesExistVerifierImpl;
@@ -104,9 +100,8 @@ public final class UserInterfaceView extends JFrame {
     private final JButton verifyCancelBtn = new JButton("Cancel");
 
     private final JTable verifierTbl = new JTable();
-
-    private final Map<String, VerifierProperty> verifierSettings = new HashMap<String, VerifierProperty>();
-    private final List<String> verifierNamesMap = new ArrayList<String>();
+    private final VerifierTableModel verifierTableModel;
+    private List<VerifierProperty> verifierProperties = new ArrayList<VerifierProperty>();
 
 
     // Components of the Advanced Settings tab
@@ -139,7 +134,15 @@ public final class UserInterfaceView extends JFrame {
 
 
     public UserInterfaceView() {
-        createVerifierSettings();
+        VerifierProperty validSchemaVerifier = new ValidSchemaNameVerifierImpl();
+        VerifierProperty localFileExistsVerifier = new LocalFilesExistVerifierImpl();
+        VerifierProperty remoteFileExistsVerifier = new RemoteFilesExistVerifierImpl();
+
+        verifierProperties.add(validSchemaVerifier);
+        verifierProperties.add(localFileExistsVerifier);
+        verifierProperties.add(remoteFileExistsVerifier);
+
+        verifierTableModel = new VerifierTableModel(verifierProperties);
 
         createBatchDetailsTab();
 
@@ -333,6 +336,10 @@ public final class UserInterfaceView extends JFrame {
         return tabs;
     }
 
+    public VerifierTableModel getTableModel() {
+        return verifierTableModel;
+    }
+
     public JTextField getUserAgentField() {
         return userAgentField;
     }
@@ -343,14 +350,6 @@ public final class UserInterfaceView extends JFrame {
 
     public JPanel getValidationTab() {
         return validationTab;
-    }
-
-    public List<String> getVerifierNamesMap() {
-        return verifierNamesMap;
-    }
-
-    public Map<String, VerifierProperty> getVerifierSettings() {
-        return verifierSettings;
     }
 
     public JTable getVerifierTbl() {
@@ -457,6 +456,7 @@ public final class UserInterfaceView extends JFrame {
         flagsDownloadCsvBtn.setEnabled(false);
         flagsReportSelectedBtn.setEnabled(false);
     }
+
     private void createLicenseTab() {
         licenseTab.setLayout(new BoxLayout(licenseTab, BoxLayout.Y_AXIS));
 
@@ -491,35 +491,14 @@ public final class UserInterfaceView extends JFrame {
     }
 
     private void createVerificationTab() {
-        validationTab.setLayout(new BoxLayout(validationTab, BoxLayout.Y_AXIS));
-
-        Vector<String> columnNames = new Vector<String>();
-        Vector<Vector<Object>> rowData = new Vector<Vector<Object>>();
-
-        columnNames.add("Verifier");
-        columnNames.add("Generates Errors");
-        columnNames.add("Is Enabled");
-
-        for (Entry<String, VerifierProperty> entry : verifierSettings.entrySet()) {
-            VerifierProperty verifier = entry.getValue();
-            Vector<Object> row = new Vector<Object>();
-
-            row.add(verifier.prettyName());
-            row.add(verifier.generatesError());
-            row.add(verifier.isEnabled());
-
-            verifierNamesMap.add(verifier.getClass().getName());
-
-            rowData.add(row);
-        }
-
-        verifierTbl.setModel(new DefaultTableModel(rowData, columnNames));
+        verifierTbl.setModel(verifierTableModel);
         verifierTbl.setPreferredScrollableViewportSize(new Dimension(400, 50));
         verifierTbl.setEnabled(false);
 
         JScrollPane verifierTblScrollPane = new JScrollPane(verifierTbl);
         verifierTbl.setFillsViewportHeight(true);
-        verifierTbl.setAutoCreateRowSorter(true);
+
+        validationTab.setLayout(new BoxLayout(validationTab, BoxLayout.Y_AXIS));
 
         validationTab.add(verifierTblScrollPane);
 
@@ -530,17 +509,6 @@ public final class UserInterfaceView extends JFrame {
         validationTab.add(verifyBatchBtnPanel);
 
         tabs.addTab("Batch Verification", validationTab);
-    }
-
-    private void createVerifierSettings() {
-        VerifierProperty validSchemaVerifier = new ValidSchemaNameVerifierImpl();
-        verifierSettings.put(ValidSchemaNameVerifierImpl.class.getName(), validSchemaVerifier);
-
-        VerifierProperty localFileExistsVerifier = new LocalFilesExistVerifierImpl();
-        verifierSettings.put(LocalFilesExistVerifierImpl.class.getName(), localFileExistsVerifier);
-
-        VerifierProperty remoteFileExistsVerifier = new RemoteFilesExistVerifierImpl();
-        verifierSettings.put(RemoteFilesExistVerifierImpl.class.getName(), remoteFileExistsVerifier);
     }
 
     private void initializeState() {

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -107,6 +107,7 @@ public final class UserInterfaceView extends JFrame {
     // Components of the Advanced Settings tab
     private final JCheckBox ignoreFilesBox = new JCheckBox("Omit bitstreams (content files) from generated SAF:");
     private final JCheckBox continueOnRemoteErrorBox = new JCheckBox("Allow writing even if remote bitstream verification flags an error:");
+    private final JCheckBox allowSelfSignedBox = new JCheckBox("Allow Self-Signed SSL Certificates:");
 
     private final JLabel itemProcessDelayLabel = new JLabel("Item Processing Delay (in milliseconds):");
     private final JLabel remoteFileTimeoutLabel = new JLabel("Remote File Timeout (in milliseconds):");
@@ -195,6 +196,10 @@ public final class UserInterfaceView extends JFrame {
     }
     public JPanel getAdvancedSettingsTab() {
         return advancedSettingsTab;
+    }
+
+    public JCheckBox getAllowSelfSignedBox() {
+        return allowSelfSignedBox;
     }
 
     public JButton getChooseInputFileBtn() {
@@ -376,6 +381,10 @@ public final class UserInterfaceView extends JFrame {
         advancedSettingsTab.setLayout(new BoxLayout(advancedSettingsTab, BoxLayout.Y_AXIS));
         advancedSettingsTab.add(ignoreFilesBox);
         advancedSettingsTab.add(continueOnRemoteErrorBox);
+        advancedSettingsTab.add(allowSelfSignedBox);
+
+        // initialize checkbox as selected.
+        allowSelfSignedBox.setSelected(true);
 
         tabs.addTab("Advanced Settings", advancedSettingsTab);
 
@@ -397,6 +406,7 @@ public final class UserInterfaceView extends JFrame {
         // initialize as disabled so that it will only be enable once a batch is assigned.
         ignoreFilesBox.setEnabled(false);
         continueOnRemoteErrorBox.setEnabled(false);
+        allowSelfSignedBox.setEnabled(false);
         itemProcessDelayField.setEnabled(false);
         remoteFileTimeoutField.setEnabled(false);
         userAgentField.setEnabled(false);

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -383,7 +383,7 @@ public final class UserInterfaceView extends JFrame {
         advancedSettingsTab.add(continueOnRemoteErrorBox);
         advancedSettingsTab.add(allowSelfSignedBox);
 
-        // initialize checkbox as selected.
+        // default to enabled.
         allowSelfSignedBox.setSelected(true);
 
         tabs.addTab("Advanced Settings", advancedSettingsTab);

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -42,7 +42,7 @@ public final class UserInterfaceView extends JFrame {
 
 
     // defaults
-    public static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:57.0) Gecko/20100101 Firefox/57.0";
+    public static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:62.0) Gecko/20100101 Firefox/62.0";
     public static final int DEFAULT_PROCESS_DELAY = 400;
     public static final int DEFAULT_REMOTE_FILE_TIMEOUT = 10000;
     public static final String DEFAULT_CSV_OUTPUT_NAME = "SAF-Flags.csv";

--- a/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/view/UserInterfaceView.java
@@ -105,9 +105,9 @@ public final class UserInterfaceView extends JFrame {
 
 
     // Components of the Advanced Settings tab
-    private final JCheckBox ignoreFilesBox = new JCheckBox("Omit bitstreams (content files) from generated SAF:");
-    private final JCheckBox continueOnRemoteErrorBox = new JCheckBox("Allow writing even if remote bitstream verification flags an error:");
-    private final JCheckBox allowSelfSignedBox = new JCheckBox("Allow Self-Signed SSL Certificates:");
+    private final JCheckBox ignoreFilesBox = new JCheckBox("Omit bitstreams (content files) from generated SAF.");
+    private final JCheckBox continueOnRemoteErrorBox = new JCheckBox("Allow writing even if remote bitstream verification flags an error.");
+    private final JCheckBox allowSelfSignedBox = new JCheckBox("Allow Self-Signed SSL Certificates.");
 
     private final JLabel itemProcessDelayLabel = new JLabel("Item Processing Delay (in milliseconds):");
     private final JLabel remoteFileTimeoutLabel = new JLabel("Remote File Timeout (in milliseconds):");

--- a/src/main/scripts/find_problematic_pdfs.sh
+++ b/src/main/scripts/find_problematic_pdfs.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# This (simple) script is designed to help find problems with a large number of downloaded PDFs.
+# This is will accept any number of directories, representing the downloaded SAF data, that are within a single top-level directory.
+# This script requires the following programs: bash, awk, sed, file, md5sum.
+#
+# A log file will be generated, designating Invalid or Missing PDFs.
+# A checksum directory will be created, which will contain files used to designate duplicate PDFs based on their md5 checksum.
+# The checksum files within that directoy only reference the duplicates.
+#   (That is to say, if document-1.pdf and document-2.pdf have identical checksums, then only document-2.pdf will be added to the checksum file).
+#   The checksum directories themselves are named after their appropriate SAF directory as passed to this script.
+
+main() {
+  local contents_file="contents"
+  local bundle_name="bundle:ORIGINAL"
+  local log_file="analysis.log"
+  local checksum_directory="checksums"
+  local directories="$1"
+  local directory=
+  local pdfs=
+  local top=$PWD
+  local write_directory=$top
+
+  if [[ $directories == "" ]] ; then
+    write_log "ERROR" "No directories specified."
+    return 1
+  fi
+
+  for directory in $directories ; do
+    cd $top
+    echo
+    echo "Processing directory '$directory'"
+
+    if [[ ! -d "$directory" ]] ; then
+      write_log "WARNING" "Invalid Directory: '$directory'."
+      continue
+    fi
+
+    if [[ ! -f "$directory/$contents_file" ]] ; then
+      write_log "WARNING" "Missing Contents File: '$directory/$contents_file'."
+      continue
+    fi
+
+    cd $top/$directory
+    pdfs=$(awk "/$bundle_name/" $contents_file | sed -e "s|[[:space:]]*$bundle_name\$||g")
+
+    if [[ $pdfs == "" ]] ; then
+      write_log "WARNING" "Empty Contents File: '$directory/$contents_file'."
+      continue
+    fi
+
+    validate_pdfs
+  done
+
+  cd $top
+
+  return 0
+}
+
+validate_pdfs() {
+  local pdf=
+  local mime=
+  local checksum=
+
+  declare -a checksums
+
+  for pdf in $pdfs ; do
+    echo " - PDF '$pdf'"
+
+    if [[ ! -f $pdf ]] ; then
+      write_log "ERROR" "Missing PDF: '$directory/$pdf'."
+      continue
+    fi
+
+    mime=$(file -b -i "$pdf" | sed -e 's|;.*$||')
+    if [[ $mime != "application/pdf" ]] ; then
+      write_log "ERROR" "Invalid PDF: '$directory/$pdf'."
+      continue
+    fi
+
+    checksum=$(md5sum $pdf | sed -e 's|[[:space:]].*$||')
+    if [[ $checksum == "" ]] ; then
+      write_log "WARNING" "Checksum Failed: '$directory/$pdf'."
+      continue
+    fi
+
+    # note: xx is prepended to checksum to prevent bash from interpreting the checksum as an integer.
+    if [[ ${checksums["xx$checksum"]} == "$checksum" ]] ; then
+      checksum_log
+    else
+      checksums["xx$checksum"]="$checksum"
+    fi
+  done
+}
+
+checksum_log() {
+  if [[ ! -d $write_directory$checksum_directory ]] ; then
+    mkdir -p $write_directory$checksum_directory
+  fi
+
+  echo "$pdf  $checksum" >> $write_directory$checksum_directory/${directory}.duplicates
+}
+
+write_log() {
+  local severity="$1"
+  local message="$2" 
+
+  echo "$severity: $message"
+  echo "$message" >> $write_directory/$log_file
+}
+
+main "$*"


### PR DESCRIPTION
Fix Potential HTTP/HTTPS Problems:
- Make sure that "SSL handshake alert: unrecognized_name" errors do not happen by disabling SNI.
- Switch to org.apache.httpcomponents.httpclient 4.5.6.
- Add support for disabling/enabling acceptance of Self-Signed Certifications that are not in the local keystore.
- Add simple detection of HTTP 200 error pages (that is HTTP 200 success pages that are really HTTP 404 pages).

Fix NULL pointer exception.
Minor update to user agent string.
Checkboxes are not always toggling as expected.